### PR TITLE
fix(haproxy): set global maxconn to avoid memory limit

### DIFF
--- a/vault-server/templates/haproxy.cfg
+++ b/vault-server/templates/haproxy.cfg
@@ -1,5 +1,6 @@
 global
    log stdout format raw local0 info
+   maxconn 3000
 
 defaults
     mode                    http


### PR DESCRIPTION
With Fedora 38 I experienced the problem reported in 
https://github.com/haproxy/haproxy/issues/2043 which
can be solved by setting global maxconn.