### PR TITLE
fix(envrc): use full path to vault's ca

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,5 @@
 export VAULT_ADDR="https://127.0.0.1"
-export VAULT_CAPATH="./vault-tls/output/ca.crt"
+export VAULT_CAPATH="$(readlink -f ./vault-tls/output/ca.crt)"
 export VAULT_TOKEN="$(cat .vault_token)"
 export MINIKUBE_PROFILE="vault-playground"
 export TF_CLI_ARGS_test="-compact-warnings"


### PR DESCRIPTION
Without using the full path vault fails with

```
$ vault status
failed to read environment: lstat ./vault-tls/output/ca.crt: no such file or directory
```

if pwd is not the base directory.